### PR TITLE
Fixed unnecessary replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v3.0.1
+
+### Fixed
+
+- Replacement `space` to `dash` between words was removed in normalize method for `CHASSIS` identifier. [#4]
+
 ## v3.0.0
 
 ### Changed
@@ -99,6 +105,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 [#2]:https://github.com/avto-dev/identity-laravel/issues/2
 [#3]:https://github.com/avto-dev/identity-laravel/issues/3
+[#4]:https://github.com/avto-dev/identity-laravel/issues/4
 
 [keepachangelog]:https://keepachangelog.com/en/1.0.0/
 [semver]:https://semver.org/spec/v2.0.0.html

--- a/src/Types/IDEntityBody.php
+++ b/src/Types/IDEntityBody.php
@@ -29,7 +29,7 @@ class IDEntityBody extends AbstractTypedIDEntity
             // Заменяем множественные пробелы - одиночными
             $value = \preg_replace('~\s+~u', ' ', trim((string) $value));
 
-            // Номализуем символы дефиса
+            // Нормализуем символы дефиса
             $value = (string) Normalizer::normalizeDashChar($value);
 
             // Заменяем множественные дефисы - одиночными

--- a/src/Types/IDEntityChassis.php
+++ b/src/Types/IDEntityChassis.php
@@ -29,17 +29,14 @@ class IDEntityChassis extends AbstractTypedIDEntity
             // Заменяем множественные пробелы - одиночными
             $value = \preg_replace('~\s+~u', ' ', trim((string) $value));
 
-            // Заменяем пробелы - дефисами
-            $value = \preg_replace('~[[:space:]]+~', '-', $value);
-
-            // Номализуем символы дефиса
+            // Нормализуем символы дефиса
             $value = (string) Normalizer::normalizeDashChar($value);
 
             // Производим замену кириллических символов на латинские аналоги
             $value = Transliterator::transliterateString(Str::upper($value), true);
 
             // Удаляем все символы, кроме разрешенных
-            $value = \preg_replace('~[^A-Z0-9\-]~u', '', $value);
+            $value = \preg_replace('~[^A-Z0-9\- ]~u', '', $value);
 
             // Заменяем множественные дефисы - одиночными
             $value = \preg_replace('~\-+~', '-', $value);

--- a/tests/Types/IDEntityChassisTest.php
+++ b/tests/Types/IDEntityChassisTest.php
@@ -57,9 +57,6 @@ class IDEntityChassisTest extends AbstractIDEntityTestCase
         // Не корректный, длинный тире
         $this->assertEquals($valid, $instance::normalize('LA130–0128818'));
 
-        // С двумя пробелами (должны преобразоваться в одиночное тире)
-        $this->assertEquals($valid, $instance::normalize(' LA130  0128818'));
-
         // С кириллицей
         $this->assertEquals($valid, $instance::normalize('Lа130-0128818'));
 
@@ -68,6 +65,9 @@ class IDEntityChassisTest extends AbstractIDEntityTestCase
 
         // Некорректные символы - удаляет
         $this->assertEquals($valid, $instance::normalize('LA130-0128№;:?№?*№%$@$%@#818'));
+
+        // С двумя пробелами (должны преобразоваться в одиночное тире)
+        $this->assertEquals('LA130 0128818', $instance::normalize(' LA130  0128818'));
     }
 
     /**


### PR DESCRIPTION
Removed replacement from `space` to `dash` in normalize method in `CHASSIS` type. [#4](https://github.com/avto-dev/identity-laravel/issues/4)