### PR TITLE
update illuminate up to 6.x

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ Fixes # (issue)
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I wrote unit tests for my code
+- [ ] I wrote unit tests for my code _(if tests is required for my changes)_
 - [ ] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/identity-laravel/blob/master/CHANGELOG.md) file
 
 <!--

--- a/.github/workflows/execute-tests.yml
+++ b/.github/workflows/execute-tests.yml
@@ -1,0 +1,46 @@
+name: Execute tests
+
+on:
+  push:
+    branches:
+      - master
+    tags-ignore:
+      - '**'
+  pull_request:
+
+jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-actions>
+  tests:
+    name: PHP ${{ matrix.php }}, ${{ matrix.setup }} setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        setup: ['basic', 'lowest']
+        php: ['7.1', '7.2', '7.3']
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@master # Action page: <https://github.com/shivammathur/setup-php>
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Install Composer 'hirak/prestissimo' package
+        run: composer global require hirak/prestissimo --update-no-dev
+
+      - name: Install lowest Composer dependencies
+        if: matrix.setup == 'lowest'
+        run: composer update --prefer-dist --no-interaction --no-suggest --prefer-lowest
+
+      - name: Install basic Composer dependencies
+        if: matrix.setup == 'basic'
+        run: composer update --prefer-dist --no-interaction --no-suggest
+
+      - name: Show most important packages versions
+        run: composer info | grep -e laravel/laravel -e phpunit/phpunit -e phpstan/phpstan
+
+      - name: Execute tests
+        run: composer test

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,15 +42,14 @@ matrix:
     - php: 7.1.3
       env: laravel=5.6
     - php: 7.1.3
-      env: laravel=5.7
-    - php: 7.1.3
       env: coverage=true
 
     - php: 7.2
-    - php: 7.2
       env: setup=lowest
     - php: 7.2
-      env: coverage=true
+      env: laravel=5.8
+    - php: 7.2
+      env: coverage=true laravel=6.*
 
     - php: 7.3
       env: setup=lowest
@@ -61,7 +60,9 @@ matrix:
     - php: 7.3
       env: laravel=5.7
     - php: 7.3
-      env: coverage=true
+      env: laravel=5.8
+    - php: 7.3
+      env: coverage=true laravel=6.*
 
     - php: nightly
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed
+
+- Maximal `illuminate/*` packages version now is `6.*`
+
+### Added
+
+- GitHub actions for a tests running
+
 ## v4.1.0
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM composer:1.8.6 AS composer
 
-FROM php:7.1.3-alpine
+FROM php:7.2.0-alpine
 
 ENV \
     COMPOSER_ALLOW_SUPERUSER="1" \

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
         "ext-json": "*",
         "avto-dev/extended-laravel-validator": "^3.0",
         "avto-dev/static-references-laravel": "^3.1",
-        "illuminate/support": ">=5.4.0 <5.9.0",
-        "illuminate/config": ">=5.4.0 <5.9.0",
-        "illuminate/contracts": ">=5.4.0 <5.9.0",
-        "illuminate/container": ">=5.4.0 <5.9.0"
+        "illuminate/support": ">=5.4.0 <5.9.0 || ~6.0",
+        "illuminate/config": ">=5.4.0 <5.9.0 || ~6.0",
+        "illuminate/contracts": ">=5.4.0 <5.9.0 || ~6.0",
+        "illuminate/container": ">=5.4.0 <5.9.0 || ~6.0"
     },
     "require-dev": {
-        "laravel/laravel": ">=5.4.0 <5.9.0",
+        "laravel/laravel": ">=5.4.0 <5.9.0 || ~6.0",
         "mockery/mockery": "^1.0",
         "phpstan/phpstan": "^0.11.3",
         "phpunit/phpunit": "~5.7.10 || ^6.4 || ~7.5"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No

## Description

### Changed

- Maximal `illuminate/*` packages version now is `6.*`

### Added

- GitHub actions for a tests running

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/app-version-laravel/blob/master/CHANGELOG.md) file

