### PR TITLE
Refactor cadastral

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,9 +1,4 @@
 parameters:
   level: 'max'
-  ignoreErrors:
-    -
-      message: '#Unsafe usage of new static\(\)#'
-      paths:
-        - src/Types/AbstractTypedIDEntity.php
   paths:
     - src

--- a/src/Helpers/CadastralNumberInfo.php
+++ b/src/Helpers/CadastralNumberInfo.php
@@ -4,6 +4,9 @@ declare(strict_types = 1);
 
 namespace AvtoDev\IDEntity\Helpers;
 
+/**
+ * @see https://ru.wikipedia.org/wiki/%D0%9A%D0%B0%D0%B4%D0%B0%D1%81%D1%82%D1%80%D0%BE%D0%B2%D1%8B%D0%B9_%D0%BD%D0%BE%D0%BC%D0%B5%D1%80
+ */
 class CadastralNumberInfo
 {
     /**

--- a/src/Helpers/CadastralNumberInfo.php
+++ b/src/Helpers/CadastralNumberInfo.php
@@ -56,7 +56,7 @@ class CadastralNumberInfo
     /**
      * Parse given cadastral number.
      *
-     * @param null|string $cadastral_number
+     * @param string|null $cadastral_number
      *
      * @return CadastralNumberInfo
      */

--- a/src/Helpers/CadastralNumberInfo.php
+++ b/src/Helpers/CadastralNumberInfo.php
@@ -9,45 +9,48 @@ class CadastralNumberInfo
     /**
      * Код субъекта.
      *
-     * @var string
+     * @var int
      */
-    protected $region_code;
+    protected $district_code;
 
     /**
      * Номер района.
      *
-     * @var string
+     * @var int
      */
-    protected $district_code;
+    protected $area_code;
 
     /**
      * Номер квартала.
      *
      * @var string
      */
-    protected $quarter_code;
+    protected $section_code;
 
     /**
      * Номер участка.
      *
      * @var string
      */
-    protected $area_code;
+    protected $parcel_number;
 
     /**
      * CadastralNumberInfo constructor.
      *
-     * @param string $region_code
-     * @param string $district_code
-     * @param string $quarter_code
-     * @param string $area_code
+     * @param int    $district_code
+     * @param int    $area_code
+     * @param string $section_code
+     * @param string $parcel_number
      */
-    protected function __construct(string $region_code, string $district_code, string $quarter_code, string $area_code)
+    protected function __construct(int $district_code,
+                                   int $area_code,
+                                   string $section_code,
+                                   string $parcel_number)
     {
-        $this->region_code   = $region_code;
         $this->district_code = $district_code;
-        $this->quarter_code  = $quarter_code;
         $this->area_code     = $area_code;
+        $this->section_code  = $section_code;
+        $this->parcel_number = $parcel_number;
     }
 
     /**
@@ -61,58 +64,58 @@ class CadastralNumberInfo
     {
         $codes = \mb_split(':', $cadastral_number ?? '');
 
-        return new static(
-            \trim($codes[0] ?? ''),
-            \trim($codes[1] ?? ''),
+        return new self(
+            (int) ($codes[0] ?? 0),
+            (int) ($codes[1] ?? 0),
             \trim($codes[2] ?? ''),
             \trim($codes[3] ?? '')
         );
     }
 
     /**
-     * @return string
+     * @return int
      */
-    public function getRegionCode(): string
-    {
-        return $this->region_code;
-    }
-
-    /**
-     * @return string
-     */
-    public function getDistrictCode(): string
+    public function getDistrictCode(): int
     {
         return $this->district_code;
     }
 
     /**
-     * @return string
+     * @return int
      */
-    public function getQuarterCode(): string
-    {
-        return $this->quarter_code;
-    }
-
-    /**
-     * @return string
-     */
-    public function getAreaCode(): string
+    public function getAreaCode(): int
     {
         return $this->area_code;
     }
 
     /**
+     * @return string
+     */
+    public function getSectionCode(): string
+    {
+        return $this->section_code;
+    }
+
+    /**
+     * @return string
+     */
+    public function getParcelNumber(): string
+    {
+        return $this->parcel_number;
+    }
+
+    /**
      * Get all parsed elements in array.
      *
-     * @return array<string, string>
+     * @return array<string, int|string>
      */
     public function getFragments(): array
     {
         return [
-            'region'   => $this->region_code,
-            'district' => $this->district_code,
-            'quarter'  => $this->quarter_code,
-            'area'     => $this->area_code,
+            'district'      => $this->district_code,
+            'area'          => $this->area_code,
+            'section'       => $this->section_code,
+            'parcel_number' => $this->parcel_number,
         ];
     }
 }

--- a/src/IDEntityInterface.php
+++ b/src/IDEntityInterface.php
@@ -90,7 +90,7 @@ interface IDEntityInterface
      * Проверяет, является ли переданное значение в $value типом $type (значения типов можно передать массивом).
      *
      * @param string          $value
-     * @param string[]|string $type
+     * @param string|string[] $type
      *
      * @return bool
      */

--- a/src/Types/AbstractTypedIDEntity.php
+++ b/src/Types/AbstractTypedIDEntity.php
@@ -28,7 +28,7 @@ abstract class AbstractTypedIDEntity extends IDEntity implements TypedIDEntityIn
      * @param string $value
      * @param bool   $make_normalization
      */
-    public function __construct(string $value, bool $make_normalization = true)
+    final public function __construct(string $value, bool $make_normalization = true)
     {
         parent::__construct();
 

--- a/src/Types/HasCadastralNumberInterface.php
+++ b/src/Types/HasCadastralNumberInterface.php
@@ -11,5 +11,5 @@ interface HasCadastralNumberInterface
      *
      * @return CadastralDistrict|null
      */
-    public function getRegionData(): ?CadastralDistrict;
+    public function getDistrictData(): ?CadastralDistrict;
 }

--- a/src/Types/IDEntityCadastralNumber.php
+++ b/src/Types/IDEntityCadastralNumber.php
@@ -51,7 +51,7 @@ class IDEntityCadastralNumber extends AbstractTypedIDEntity implements HasCadast
         /** @var CadastralDistricts $districts */
         $districts = static::getContainer()->make(CadastralDistricts::class);
 
-        return $districts->getByCode((int) $this->getNumberInfo()->getDistrictCode());
+        return $districts->getByCode($this->getNumberInfo()->getDistrictCode());
     }
 
     /**

--- a/src/Types/IDEntityCadastralNumber.php
+++ b/src/Types/IDEntityCadastralNumber.php
@@ -46,12 +46,12 @@ class IDEntityCadastralNumber extends AbstractTypedIDEntity implements HasCadast
     /**
      * {@inheritdoc}
      */
-    public function getRegionData(): ?CadastralDistrict
+    public function getDistrictData(): ?CadastralDistrict
     {
         /** @var CadastralDistricts $districts */
         $districts = static::getContainer()->make(CadastralDistricts::class);
 
-        return $districts->getByCode((int) $this->getNumberInfo()->getRegionCode());
+        return $districts->getByCode((int) $this->getNumberInfo()->getDistrictCode());
     }
 
     /**
@@ -64,10 +64,10 @@ class IDEntityCadastralNumber extends AbstractTypedIDEntity implements HasCadast
 
         $validated = \is_string($this->value) && $validator->passes('', $this->value);
 
-        $region_data = $this->getRegionData();
+        $district_data = $this->getDistrictData();
 
         return $validated
-               && $region_data instanceof CadastralDistrict
-               && $region_data->hasAreaWithCode((int) $this->getNumberInfo()->getDistrictCode());
+               && $district_data instanceof CadastralDistrict
+               && $district_data->hasAreaWithCode($this->getNumberInfo()->getAreaCode());
     }
 }

--- a/tests/Helpers/CadastralNumberInfoTest.php
+++ b/tests/Helpers/CadastralNumberInfoTest.php
@@ -21,49 +21,52 @@ class CadastralNumberInfoTest extends AbstractTestCase
         do {
             $cadastral_number = \sprintf(
                 '%02d:%02d:%06d:%03d',
-                $region = \random_int(1, 91),
-                $district = \random_int(1, 9),
-                $quarter = \random_int(1, 999999),
-                $area = \random_int(1, 999)
+                $district = \random_int(1, 91),
+                $area = \random_int(1, 9),
+                $section = \random_int(1, 999999),
+                $parcel_number = \random_int(1, 999)
             );
             $attempts++;
             $helper = CadastralNumberInfo::parse($cadastral_number);
-            $this->assertEquals($helper->getRegionCode(), $region);
             $this->assertEquals($helper->getDistrictCode(), $district);
-            $this->assertEquals($helper->getQuarterCode(), $quarter);
             $this->assertEquals($helper->getAreaCode(), $area);
+            $this->assertEquals($helper->getSectionCode(), $section);
+            $this->assertEquals($helper->getParcelNumber(), $parcel_number);
         } while ($attempts < 10);
 
         // Check with empty string
         $helper = CadastralNumberInfo::parse('');
-        $this->assertInternalType('object', $helper);
-        $this->assertSame(['region' => '', 'district' => '', 'quarter' => '', 'area' => ''], $helper->getFragments());
+        $this->assertIsObject($helper);
+        $this->assertSame(
+            ['district' => 0, 'area' => 0, 'section' => '', 'parcel_number' => ''],
+            $helper->getFragments()
+        );
 
         // Check if value contains letters
         $helper = CadastralNumberInfo::parse('foo:bar:this:shit');
         $this->assertSame(
-            ['region' => 'foo', 'district' => 'bar', 'quarter' => 'this', 'area' => 'shit'],
+            ['district' => 0, 'area' => 0, 'section' => 'this', 'parcel_number' => 'shit'],
             $helper->getFragments()
         );
 
         // Check \trim in fragments
         $helper = CadastralNumberInfo::parse('   foo  : bar:this :shit   ');
         $this->assertSame(
-            ['region' => 'foo', 'district' => 'bar', 'quarter' => 'this', 'area' => 'shit'],
+            ['district' => 0, 'area' => 0, 'section' => 'this', 'parcel_number' => 'shit'],
             $helper->getFragments()
         );
 
         // Check without delimiter
         $helper = CadastralNumberInfo::parse('   foo   ');
         $this->assertSame(
-            ['region' => 'foo', 'district' => '', 'quarter' => '', 'area' => ''],
+            ['district' => 0, 'area' => 0, 'section' => '', 'parcel_number' => ''],
             $helper->getFragments()
         );
 
         // Check with null
         $helper = CadastralNumberInfo::parse(null);
         $this->assertSame(
-            ['region' => '', 'district' => '', 'quarter' => '', 'area' => ''],
+            ['district' => 0, 'area' => 0, 'section' => '', 'parcel_number' => ''],
             $helper->getFragments()
         );
     }

--- a/tests/IDEntityTest.php
+++ b/tests/IDEntityTest.php
@@ -264,6 +264,7 @@ class IDEntityTest extends AbstractTestCase
     /**
      * Тест метода 'make' с передачей неизвестного типа.
      *
+     * @group Eldar
      * @return void
      */
     public function testMakeWithUnknownType(): void

--- a/tests/IDEntityTest.php
+++ b/tests/IDEntityTest.php
@@ -265,6 +265,7 @@ class IDEntityTest extends AbstractTestCase
      * Тест метода 'make' с передачей неизвестного типа.
      *
      * @group Eldar
+     *
      * @return void
      */
     public function testMakeWithUnknownType(): void

--- a/tests/IDEntityTest.php
+++ b/tests/IDEntityTest.php
@@ -264,8 +264,6 @@ class IDEntityTest extends AbstractTestCase
     /**
      * Тест метода 'make' с передачей неизвестного типа.
      *
-     * @group Eldar
-     *
      * @return void
      */
     public function testMakeWithUnknownType(): void

--- a/tests/Types/AbstractIDEntityTestCase.php
+++ b/tests/Types/AbstractIDEntityTestCase.php
@@ -143,7 +143,7 @@ abstract class AbstractIDEntityTestCase extends AbstractTestCase
      *
      * @return void
      */
-    abstract public function testGetType();
+    abstract public function testGetType(): void;
 
     /**
      * Тест методов преобразования объекта в массив и json.
@@ -165,26 +165,26 @@ abstract class AbstractIDEntityTestCase extends AbstractTestCase
      *
      * @return void
      */
-    abstract public function testIsValid();
+    abstract public function testIsValid(): void;
 
     /**
      * Тест метода нормализации значения.
      *
      * @return void
      */
-    abstract public function testNormalize();
+    abstract public function testNormalize(): void;
 
     /**
      * Тест работы метода нормализации с некорректными данными на входе.
      *
-     * @return null
+     * @return void
      */
     public function testNormalizeWithInvalidInputData(): void
     {
         $invalid_values = [
             new stdClass,
             [],
-            function () {
+            function (): void {
             },
         ];
 

--- a/tests/Types/IDEntityCadastralNumberTest.php
+++ b/tests/Types/IDEntityCadastralNumberTest.php
@@ -147,12 +147,12 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
         $this->assertFalse($this->instance->setValue(':D61:41:123456:102360')->isValid());
         // Засовываем всякую шляпу
         foreach ([
-                     function (): void {
-                     },
-                     new static,
-                     new stdClass,
-                     ['foo' => 'bar'],
-                 ] as $item) {
+            function (): void {
+            },
+            new static,
+            new stdClass,
+            ['foo' => 'bar'],
+        ] as $item) {
             $this->assertNull($this->instance::normalize($item));
         }
     }

--- a/tests/Types/IDEntityCadastralNumberTest.php
+++ b/tests/Types/IDEntityCadastralNumberTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace AvtoDev\IDEntity\Tests\Types;
 
+use stdClass;
 use AvtoDev\IDEntity\IDEntity;
 use AvtoDev\IDEntity\Helpers\CadastralNumberInfo;
 use AvtoDev\IDEntity\Types\IDEntityCadastralNumber;
@@ -22,7 +23,7 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
     /**
      * {@inheritdoc}
      */
-    public function testGetType()
+    public function testGetType(): void
     {
         $this->assertEquals(IDEntity::ID_TYPE_CADASTRAL_NUMBER, $this->instance->getType());
     }
@@ -30,9 +31,10 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
     /**
      * {@inheritdoc}
      */
-    public function testIsValid()
+    public function testIsValid(): void
     {
         $valid = [
+            '02:04:000221:2',
             '09:04:0134001:102',
             '10:01:0030104:691',
             '11:05:0105013:390',
@@ -61,6 +63,7 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
             '37:29:010121:75',
             '38:06:100801:26333',
             '39:15:131926:797',
+            '39:05:131926:7',
         ];
 
         foreach ($valid as $value) {
@@ -128,7 +131,7 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
     /**
      * {@inheritdoc}
      */
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $valid = $this->getValidValue();
 
@@ -144,12 +147,12 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
         $this->assertFalse($this->instance->setValue(':D61:41:123456:102360')->isValid());
         // Засовываем всякую шляпу
         foreach ([
-            function () {
-            },
-            new static,
-            new \stdClass,
-            ['foo' => 'bar'],
-        ] as $item) {
+                     function (): void {
+                     },
+                     new static,
+                     new stdClass,
+                     ['foo' => 'bar'],
+                 ] as $item) {
             $this->assertNull($this->instance::normalize($item));
         }
     }

--- a/tests/Types/IDEntityCadastralNumberTest.php
+++ b/tests/Types/IDEntityCadastralNumberTest.php
@@ -144,12 +144,12 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
         $this->assertFalse($this->instance->setValue(':D61:41:123456:102360')->isValid());
         // Засовываем всякую шляпу
         foreach ([
-            function () {
-            },
-            new static,
-            new \stdClass,
-            ['foo' => 'bar'],
-        ] as $item) {
+                     function () {
+                     },
+                     new static,
+                     new \stdClass,
+                     ['foo' => 'bar'],
+                 ] as $item) {
             $this->assertNull($this->instance::normalize($item));
         }
     }
@@ -160,14 +160,14 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
     public function testGetNumberInfo(): void
     {
         $this->assertInstanceOf(CadastralNumberInfo::class, $this->instance->getNumberInfo());
-        $this->assertSame('66', $this->instance->getNumberInfo()->getRegionCode());
-        $this->assertSame('41', $this->instance->getNumberInfo()->getDistrictCode());
-        $this->assertSame('0105001', $this->instance->getNumberInfo()->getQuarterCode());
-        $this->assertSame('3', $this->instance->getNumberInfo()->getAreaCode());
+        $this->assertSame(66, $this->instance->getNumberInfo()->getDistrictCode());
+        $this->assertSame(41, $this->instance->getNumberInfo()->getAreaCode());
+        $this->assertSame('0105001', $this->instance->getNumberInfo()->getSectionCode());
+        $this->assertSame('3', $this->instance->getNumberInfo()->getParcelNumber());
 
         $this->instance->setValue('52:25');
         $this->assertSame(
-            ['region' => '52', 'district' => '25', 'quarter' => '', 'area' => ''],
+            ['district' => 52, 'area' => 25, 'section' => '', 'parcel_number' => ''],
             $this->instance->getNumberInfo()->getFragments()
         );
     }
@@ -177,10 +177,10 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
      */
     public function testGetRegionData(): void
     {
-        $this->assertInstanceOf(CadastralDistrict::class, $this->instance->getRegionData());
+        $this->assertInstanceOf(CadastralDistrict::class, $this->instance->getDistrictData());
 
         $this->instance->setValue('');
-        $this->assertNull($this->instance->getRegionData());
+        $this->assertNull($this->instance->getDistrictData());
     }
 
     /**

--- a/tests/Types/IDEntityCadastralNumberTest.php
+++ b/tests/Types/IDEntityCadastralNumberTest.php
@@ -144,12 +144,12 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
         $this->assertFalse($this->instance->setValue(':D61:41:123456:102360')->isValid());
         // Засовываем всякую шляпу
         foreach ([
-                     function () {
-                     },
-                     new static,
-                     new \stdClass,
-                     ['foo' => 'bar'],
-                 ] as $item) {
+            function () {
+            },
+            new static,
+            new \stdClass,
+            ['foo' => 'bar'],
+        ] as $item) {
             $this->assertNull($this->instance::normalize($item));
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes

## Description
> Changes for merging into `massive-update` branch

The changes concern the names of subparts of cadastral numbers.

For example: **66:41:123456:78**
- **66** - _district code_
- **41** - _area code_
- **123456** - _section code_
- **78** - _parcel number_

Fixes # (issue)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code
- [ ] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/identity-laravel/blob/master/CHANGELOG.md) file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
