### PR TITLE
Change all parts from cadastral number to int

### DIFF
--- a/src/Helpers/CadastralNumberInfo.php
+++ b/src/Helpers/CadastralNumberInfo.php
@@ -111,4 +111,17 @@ class CadastralNumberInfo implements \Illuminate\Contracts\Support\Arrayable
             'parcel_number' => $this->parcel_number,
         ];
     }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return \sprintf('%02d:%02d:%07d:%d',
+            $this->district_code,
+            $this->area_code,
+            $this->section_code,
+            $this->parcel_number
+        );
+    }
 }

--- a/src/Helpers/CadastralNumberInfo.php
+++ b/src/Helpers/CadastralNumberInfo.php
@@ -49,6 +49,19 @@ class CadastralNumberInfo implements \Illuminate\Contracts\Support\Arrayable
     }
 
     /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return \sprintf('%02d:%02d:%07d:%d',
+            $this->district_code,
+            $this->area_code,
+            $this->section_code,
+            $this->parcel_number
+        );
+    }
+
+    /**
      * Parse given cadastral number.
      *
      * @param string|null $cadastral_number
@@ -110,18 +123,5 @@ class CadastralNumberInfo implements \Illuminate\Contracts\Support\Arrayable
             'section'       => $this->section_code,
             'parcel_number' => $this->parcel_number,
         ];
-    }
-
-    /**
-     * @return string
-     */
-    public function __toString()
-    {
-        return \sprintf('%02d:%02d:%07d:%d',
-            $this->district_code,
-            $this->area_code,
-            $this->section_code,
-            $this->parcel_number
-        );
     }
 }

--- a/src/Helpers/CadastralNumberInfo.php
+++ b/src/Helpers/CadastralNumberInfo.php
@@ -20,27 +20,27 @@ class CadastralNumberInfo implements \Illuminate\Contracts\Support\Arrayable
     protected $area_code;
 
     /**
-     * @var string
+     * @var int
      */
     protected $section_code;
 
     /**
-     * @var string
+     * @var int
      */
     protected $parcel_number;
 
     /**
      * Create a new CadastralNumberInfo instance.
      *
-     * @param int    $district_code
-     * @param int    $area_code
-     * @param string $section_code
-     * @param string $parcel_number
+     * @param int $district_code
+     * @param int $area_code
+     * @param int $section_code
+     * @param int $parcel_number
      */
     protected function __construct(int $district_code,
                                    int $area_code,
-                                   string $section_code,
-                                   string $parcel_number)
+                                   int $section_code,
+                                   int $parcel_number)
     {
         $this->district_code = $district_code;
         $this->area_code     = $area_code;
@@ -62,8 +62,8 @@ class CadastralNumberInfo implements \Illuminate\Contracts\Support\Arrayable
         return new self(
             (int) ($codes[0] ?? 0),
             (int) ($codes[1] ?? 0),
-            \trim($codes[2] ?? ''),
-            \trim($codes[3] ?? '')
+            (int) ($codes[2] ?? 0),
+            (int) ($codes[3] ?? 0)
         );
     }
 
@@ -84,23 +84,23 @@ class CadastralNumberInfo implements \Illuminate\Contracts\Support\Arrayable
     }
 
     /**
-     * @return string
+     * @return int
      */
-    public function getSectionCode(): string
+    public function getSectionCode(): int
     {
         return $this->section_code;
     }
 
     /**
-     * @return string
+     * @return int
      */
-    public function getParcelNumber(): string
+    public function getParcelNumber(): int
     {
         return $this->parcel_number;
     }
 
     /**
-     * @return array{district:int, area:int, section:string, parcel_number:string}
+     * @return array{district:int, area:int, section:int, parcel_number:int}
      */
     public function toArray(): array
     {

--- a/src/Types/IDEntityCadastralNumber.php
+++ b/src/Types/IDEntityCadastralNumber.php
@@ -41,10 +41,10 @@ class IDEntityCadastralNumber extends AbstractTypedIDEntity implements HasCadast
             $parts = \explode(':', $value);
 
             return \sprintf('%02d:%02d:%07d:%d',
-                (int) ($parts[0] ?? 0),
-                (int) ($parts[1] ?? 0),
-                (int) ($parts[2] ?? 0),
-                (int) ($parts[3] ?? 0)
+                (int) $parts[0],
+                (int) $parts[1],
+                (int) $parts[2],
+                (int) $parts[3]
             );
         } catch (Exception $e) {
             return null;
@@ -90,17 +90,5 @@ class IDEntityCadastralNumber extends AbstractTypedIDEntity implements HasCadast
         }
 
         return false;
-    }
-
-    /**
-     * @param bool $format
-     *
-     * @return string|null
-     */
-    public function getValue(bool $format = false): ?string
-    {
-        return $format
-            ? (string) $this->getNumberInfo()
-            : parent::getValue();
     }
 }

--- a/src/Types/IDEntityCadastralNumber.php
+++ b/src/Types/IDEntityCadastralNumber.php
@@ -83,4 +83,16 @@ class IDEntityCadastralNumber extends AbstractTypedIDEntity implements HasCadast
 
         return false;
     }
+
+    /**
+     * @param bool $format
+     *
+     * @return string|null
+     */
+    public function getValue(bool $format = false): ?string
+    {
+        return $format
+            ? (string) $this->getNumberInfo()
+            : parent::getValue();
+    }
 }

--- a/src/Types/IDEntityCadastralNumber.php
+++ b/src/Types/IDEntityCadastralNumber.php
@@ -37,7 +37,15 @@ class IDEntityCadastralNumber extends AbstractTypedIDEntity implements HasCadast
     {
         try {
             // Remove all chars except allowed (numbers and ':')
-            return (string) \preg_replace('~[^\d:]~u', '', (string) $value);
+            $value = (string) \preg_replace('~[^\d:]~u', '', (string) $value);
+            $parts = \explode(':', $value);
+
+            return \sprintf('%02d:%02d:%07d:%d',
+                (int) ($parts[0] ?? 0),
+                (int) ($parts[1] ?? 0),
+                (int) ($parts[2] ?? 0),
+                (int) ($parts[3] ?? 0)
+            );
         } catch (Exception $e) {
             return null;
         }

--- a/src/Types/IDEntityCadastralNumber.php
+++ b/src/Types/IDEntityCadastralNumber.php
@@ -85,7 +85,8 @@ class IDEntityCadastralNumber extends AbstractTypedIDEntity implements HasCadast
                 $district_data = $this->getDistrictData();
 
                 return $district_data instanceof CadastralDistrict
-                       && $district_data->hasAreaWithCode($this->getNumberInfo()->getAreaCode());
+                       && $district_data->hasAreaWithCode($this->getNumberInfo()->getAreaCode())
+                       && $this->getNumberInfo()->getParcelNumber() > 0;
             }
         }
 

--- a/tests/Helpers/CadastralNumberInfoTest.php
+++ b/tests/Helpers/CadastralNumberInfoTest.php
@@ -38,35 +38,35 @@ class CadastralNumberInfoTest extends AbstractTestCase
         $helper = CadastralNumberInfo::parse('');
         $this->assertIsObject($helper);
         $this->assertSame(
-            ['district' => 0, 'area' => 0, 'section' => '', 'parcel_number' => ''],
+            ['district' => 0, 'area' => 0, 'section' => 0, 'parcel_number' => 0],
             $helper->toArray()
         );
 
         // Check if value contains letters
         $helper = CadastralNumberInfo::parse('foo:bar:this:shit');
         $this->assertSame(
-            ['district' => 0, 'area' => 0, 'section' => 'this', 'parcel_number' => 'shit'],
+            ['district' => 0, 'area' => 0, 'section' => 0, 'parcel_number' => 0],
             $helper->toArray()
         );
 
         // Check \trim in fragments
         $helper = CadastralNumberInfo::parse('   foo  : bar:this :shit   ');
         $this->assertSame(
-            ['district' => 0, 'area' => 0, 'section' => 'this', 'parcel_number' => 'shit'],
+            ['district' => 0, 'area' => 0, 'section' => 0, 'parcel_number' => 0],
             $helper->toArray()
         );
 
         // Check without delimiter
         $helper = CadastralNumberInfo::parse('   foo   ');
         $this->assertSame(
-            ['district' => 0, 'area' => 0, 'section' => '', 'parcel_number' => ''],
+            ['district' => 0, 'area' => 0, 'section' => 0, 'parcel_number' => 0],
             $helper->toArray()
         );
 
         // Check with null
         $helper = CadastralNumberInfo::parse(null);
         $this->assertSame(
-            ['district' => 0, 'area' => 0, 'section' => '', 'parcel_number' => ''],
+            ['district' => 0, 'area' => 0, 'section' => 0, 'parcel_number' => 0],
             $helper->toArray()
         );
     }

--- a/tests/Types/IDEntityCadastralNumberTest.php
+++ b/tests/Types/IDEntityCadastralNumberTest.php
@@ -187,6 +187,17 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
     }
 
     /**
+     * @return void
+     */
+    public function testGetValue(): void
+    {
+        $this->instance->setValue('04:5:000006:7');
+
+        $this->assertSame('04:05:0000006:7', $this->instance->getValue(true));
+        $this->assertSame('04:5:000006:7', $this->instance->getValue(false));
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getClassName(): string

--- a/tests/Types/IDEntityCadastralNumberTest.php
+++ b/tests/Types/IDEntityCadastralNumberTest.php
@@ -67,7 +67,7 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
         ];
 
         foreach ($valid as $value) {
-            $this->assertTrue($this->instance->setValue($value, false)->isValid(), $value);
+            $this->assertTrue($this->instance->setValue($value)->isValid(), $value);
         }
 
         $invalid = [
@@ -124,7 +124,7 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
         ];
 
         foreach ($invalid as $value) {
-            $this->assertFalse($this->instance->setValue($value, false)->isValid(), $value);
+            $this->assertFalse($this->instance->setValue($value)->isValid(), $value);
         }
     }
 
@@ -159,6 +159,8 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
 
     /**
      * Test of method getNumberInfo.
+     *
+     * @group Eldar
      */
     public function testGetNumberInfo(): void
     {
@@ -169,8 +171,10 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
         $this->assertSame(3, $this->instance->getNumberInfo()->getParcelNumber());
 
         $this->instance->setValue('52:25');
+        $this->assertNull($this->instance->getValue());
+
         $this->assertSame(
-            ['district' => 52, 'area' => 25, 'section' => 0, 'parcel_number' => 0],
+            ['district' => 0, 'area' => 0, 'section' => 0, 'parcel_number' => 0],
             $this->instance->getNumberInfo()->toArray()
         );
     }
@@ -191,10 +195,16 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
      */
     public function testGetValue(): void
     {
-        $this->instance->setValue('04:5:000006:7');
+        // After normalization, missing ZERO will be added.
+        $this->instance->setValue('4:5:6:7');
 
-        $this->assertSame('04:05:0000006:7', $this->instance->getValue(true));
-        $this->assertSame('04:05:0000006:7', $this->instance->getValue(false));
+        $this->assertSame('04:05:0000006:7', $this->instance->getValue());
+
+        // Not enough numbers in cadastral number
+        foreach (['52', '52:', '52:0', '52:0:', '52:0:1',] as $value) {
+            $this->instance->setValue($value);
+            $this->assertNull($this->instance->getValue());
+        }
     }
 
     /**

--- a/tests/Types/IDEntityCadastralNumberTest.php
+++ b/tests/Types/IDEntityCadastralNumberTest.php
@@ -64,6 +64,9 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
             '38:06:100801:26333',
             '39:15:131926:797',
             '39:05:131926:7',
+
+            // Last part more than 1
+            '66:41:0:1',
         ];
 
         foreach ($valid as $value) {
@@ -71,6 +74,9 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
         }
 
         $invalid = [
+            '0:0:0:0',
+            '66:0:0:0',
+            '66:41:0:0',
             '359:924:190:795',
             '5:01:4286525/047215',
             '0:22:4357409:744560',
@@ -133,18 +139,21 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
      */
     public function testNormalize(): void
     {
-        $valid = $this->getValidValue();
 
-        // Пробелы с двум сторон
-        $this->assertEquals($valid, $this->instance::normalize(' ' . $valid . ' '));
+        /**
+         * @todo Incomplete test
+         */
+        $data = [
+            '6+6:/4$1:;0(1%^0)&5*-0!0@1#:=?3'       => '66:41:0105001:3',
+            'Start6Шесть6:4One1:01ZeRO05001:ThrEE3' => '66:41:0105001:3',
+            'D61:41:123456:102360'                  => '61:41:0123456:102360',
+        ];
 
-        // Запрещенные символы
-        $this->assertEquals($valid, $this->instance::normalize('6+6:/4$1:;0(1%^0)&5*-0!0@1#:=?3'));
+        foreach ($data as $invalid => $valid) {
+            $this->assertEquals($valid, $this->instance::normalize($invalid));
+            $this->assertTrue($this->instance->setValue($invalid)->isValid());
+        }
 
-        // С буквами
-        $this->assertEquals($valid, $this->instance::normalize('Start6Шесть6:4One1:01ZeRO05001:ThrEE3'));
-        //Первый символ не цифра
-        $this->assertFalse($this->instance->setValue(':D61:41:123456:102360')->isValid());
         // Засовываем всякую шляпу
         foreach ([
                      function (): void {

--- a/tests/Types/IDEntityCadastralNumberTest.php
+++ b/tests/Types/IDEntityCadastralNumberTest.php
@@ -149,7 +149,7 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
         ];
 
         foreach ($data as $invalid => $valid) {
-            $this->assertEquals($valid, $this->instance::normalize($invalid));
+            $this->assertSame($valid, $this->instance::normalize($invalid));
             $this->assertTrue($this->instance->setValue($invalid)->isValid());
         }
 
@@ -166,12 +166,12 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
 
         // Засовываем всякую шляпу
         foreach ([
-                     function (): void {
-                     },
-                     new static,
-                     new stdClass,
-                     ['foo' => 'bar'],
-                 ] as $item) {
+            function (): void {
+            },
+            new static,
+            new stdClass,
+            ['foo' => 'bar'],
+        ] as $item) {
             $this->assertNull($this->instance::normalize($item));
         }
     }
@@ -220,7 +220,7 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
         $this->assertSame('04:05:0000006:7', $this->instance->getValue());
 
         // Not enough numbers in cadastral number
-        foreach (['52', '52:', '52:0', '52:0:', '52:0:1',] as $value) {
+        foreach (['52', '52:', '52:0', '52:0:', '52:0:1'] as $value) {
             $this->instance->setValue($value);
             $this->assertNull($this->instance->getValue());
         }

--- a/tests/Types/IDEntityCadastralNumberTest.php
+++ b/tests/Types/IDEntityCadastralNumberTest.php
@@ -147,12 +147,12 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
         $this->assertFalse($this->instance->setValue(':D61:41:123456:102360')->isValid());
         // Засовываем всякую шляпу
         foreach ([
-            function (): void {
-            },
-            new static,
-            new stdClass,
-            ['foo' => 'bar'],
-        ] as $item) {
+                     function (): void {
+                     },
+                     new static,
+                     new stdClass,
+                     ['foo' => 'bar'],
+                 ] as $item) {
             $this->assertNull($this->instance::normalize($item));
         }
     }
@@ -165,12 +165,12 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
         $this->assertInstanceOf(CadastralNumberInfo::class, $this->instance->getNumberInfo());
         $this->assertSame(66, $this->instance->getNumberInfo()->getDistrictCode());
         $this->assertSame(41, $this->instance->getNumberInfo()->getAreaCode());
-        $this->assertSame('0105001', $this->instance->getNumberInfo()->getSectionCode());
-        $this->assertSame('3', $this->instance->getNumberInfo()->getParcelNumber());
+        $this->assertSame(105001, $this->instance->getNumberInfo()->getSectionCode());
+        $this->assertSame(3, $this->instance->getNumberInfo()->getParcelNumber());
 
         $this->instance->setValue('52:25');
         $this->assertSame(
-            ['district' => 52, 'area' => 25, 'section' => '', 'parcel_number' => ''],
+            ['district' => 52, 'area' => 25, 'section' => 0, 'parcel_number' => 0],
             $this->instance->getNumberInfo()->toArray()
         );
     }

--- a/tests/Types/IDEntityCadastralNumberTest.php
+++ b/tests/Types/IDEntityCadastralNumberTest.php
@@ -67,7 +67,7 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
         ];
 
         foreach ($valid as $value) {
-            $this->assertTrue($this->instance->setValue($value)->isValid(), $value);
+            $this->assertTrue($this->instance->setValue($value, false)->isValid(), $value);
         }
 
         $invalid = [
@@ -124,7 +124,7 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
         ];
 
         foreach ($invalid as $value) {
-            $this->assertFalse($this->instance->setValue($value)->isValid(), $value);
+            $this->assertFalse($this->instance->setValue($value, false)->isValid(), $value);
         }
     }
 
@@ -194,7 +194,7 @@ class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
         $this->instance->setValue('04:5:000006:7');
 
         $this->assertSame('04:05:0000006:7', $this->instance->getValue(true));
-        $this->assertSame('04:5:000006:7', $this->instance->getValue(false));
+        $this->assertSame('04:05:0000006:7', $this->instance->getValue(false));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No

## Description

Casting all parts of the _cadastral number_, after exploding by the ":" sign, to an **integer** type

Fixes # (issue)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code
- [ ] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/identity-laravel/blob/master/CHANGELOG.md) file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
