### PR TITLE
Laravel 10 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ on:
 jobs: # Docs: <https://git.io/JvxXE>
   php:
     name: PHP ${{ matrix.php }}, ${{ matrix.setup }} setup, laravel ${{ matrix.laravel }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -21,15 +21,10 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['7.3', '7.4', '8.0']
-        include:
-          - php: '7.3'
-            setup: default
-            coverage: no
-            laravel: '^7.0'
+        php: ['8.0', '8.1', '8.2']
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 # Action page: <https://github.com/shivammathur/setup-php>
@@ -39,12 +34,12 @@ jobs: # Docs: <https://git.io/JvxXE>
 
       - name: Get Composer Cache Directory # Docs: <https://git.io/JfAKn#php---composer>
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "output_dir=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies # Docs: <https://git.io/JfAKn#php---composer>
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.output_dir }}
           key: ${{ runner.os }}-composer-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
@@ -73,7 +68,7 @@ jobs: # Docs: <https://git.io/JvxXE>
           XDEBUG_MODE: coverage
         run: composer test-cover
 
-      - uses: codecov/codecov-action@v1 # Docs: <https://github.com/codecov/codecov-action>
+      - uses: codecov/codecov-action@v3 # Docs: <https://github.com/codecov/codecov-action>
         if: matrix.coverage == 'yes'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -83,10 +78,10 @@ jobs: # Docs: <https://git.io/JvxXE>
 
   lint-changelog:
     name: Lint changelog file
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Lint changelog file
         uses: docker://avtodev/markdown-lint:v1 # Action page: <https://github.com/avto-dev/markdown-lint>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 - Minimal require PHP version now is `8.0.2`
 - Composer version up to `2.6.5`
 - Package `phpstan/phpstan` up to `^1.10`
-- Package `avto-dev/extended-laravel-validator` up to `^3.7`
 - Package `avto-dev/static-references-laravel` up to `^4.5`
+- Package `avto-dev/extended-laravel-validator` up to `^3.7`
 
 ## v5.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Support Laravel `10.x`
+- Support PHPUnit `v10`
+
+### Changed
+
+- Minimal require PHP version now is `8.0.2`
+- Composer version up to `2.6.5`
+- Package `phpstan/phpstan` up to `^1.10`
+- Package `avto-dev/extended-laravel-validator` up to `^3.7`
+- Package `avto-dev/static-references-laravel` up to `^4.5`
+
 ## v5.6.0
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@ FROM php:8.0-alpine
 
 ENV COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.0.7 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.6.5 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
-    && apk add --no-cache --virtual .build-deps autoconf pkgconf make g++ gcc 1>/dev/null \
+    && apk add --no-cache --virtual .build-deps linux-headers autoconf pkgconf make g++ gcc 1>/dev/null \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-3.0.0 1>/dev/null \
+    && pecl install xdebug-3.2.0 1>/dev/null \
     && apk del .build-deps \
     && mkdir --parents --mode=777 /src ${COMPOSER_HOME}/cache/repo ${COMPOSER_HOME}/cache/files \
     && ln -s /usr/bin/composer /usr/bin/c \

--- a/composer.json
+++ b/composer.json
@@ -14,21 +14,21 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^8.0.2",
         "ext-mbstring": "*",
         "ext-json": "*",
-        "avto-dev/extended-laravel-validator": "^3.2",
-        "avto-dev/static-references-laravel": "^4.0",
-        "illuminate/support": "~6.0 || ~7.0 || ~8.0 || ~9.0",
-        "illuminate/config": "~6.0 || ~7.0 || ~8.0 || ~9.0",
-        "illuminate/contracts": "~6.0 || ~7.0 || ~8.0 || ~9.0",
-        "illuminate/container": "~6.0 || ~7.0 || ~8.0 || ~9.0",
+        "avto-dev/extended-laravel-validator": "^3.7",
+        "avto-dev/static-references-laravel": "^4.5",
+        "illuminate/support": "~9.0 || ~10.0",
+        "illuminate/config": "~9.0 || ~10.0",
+        "illuminate/contracts": "~9.0 || ~10.0",
+        "illuminate/container": "~9.0 || ~10.0",
         "danielstjules/stringy": "~3.1.0"
     },
     "require-dev": {
-        "laravel/laravel": "~6.0 || ~7.0 || ~8.0 || ~9.0",
-        "phpstan/phpstan": "~0.12.34",
-        "phpunit/phpunit": "^9.3"
+        "laravel/laravel": "~9.0 || ~10.0",
+        "phpstan/phpstan": "~1.10",
+        "phpunit/phpunit": "^9.6 || ^10.4"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
          bootstrap="./tests/bootstrap.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         forceCoversAnnotation="true"
-         stopOnFailure="false">
+         forceCoversAnnotation="true">
 
     <testsuites>
         <testsuite name="Unit">

--- a/src/IDEntity.php
+++ b/src/IDEntity.php
@@ -87,7 +87,7 @@ class IDEntity implements IDEntityInterface
      *
      * Note: Order is important for automatic detection.
      *
-     * @return array<string, class-string>
+     * @return array<string, class-string<TypedIDEntityInterface>>
      */
     protected static function getTypesMap(): array
     {
@@ -106,13 +106,14 @@ class IDEntity implements IDEntityInterface
     /**
      * Get an extended types map, declared in configuration file.
      *
-     * @return array<string, class-string>
+     * @return array<string, class-string<TypedIDEntityInterface>>
      */
     protected static function getExtendedTypesMap(): array
     {
         /** @var ConfigRepository $config */
         $config = static::getContainer()->make(ConfigRepository::class);
 
+        /** @var array<string, class-string<TypedIDEntityInterface>> */
         return (array) $config->get(ServiceProvider::getConfigRootKeyName() . '.extended_types_map', []);
     }
 
@@ -121,7 +122,7 @@ class IDEntity implements IDEntityInterface
      *
      * @param string|null $type
      *
-     * @return class-string|null
+     * @return class-string<TypedIDEntityInterface>|null
      */
     protected static function getEntityClassByType(?string $type): ?string
     {

--- a/src/Types/IDEntityUnknown.php
+++ b/src/Types/IDEntityUnknown.php
@@ -30,6 +30,7 @@ class IDEntityUnknown extends AbstractTypedIDEntity
     public static function normalize($value): ?string
     {
         try {
+            /** @throws \Throwable */
             return (string) $value;
         } catch (\Throwable $e) {
             return null;

--- a/tests/Types/IDEntityBodyTest.php
+++ b/tests/Types/IDEntityBodyTest.php
@@ -9,7 +9,7 @@ use AvtoDev\IDEntity\IDEntityInterface;
 use AvtoDev\IDEntity\Types\IDEntityBody;
 
 /**
- * @covers \AvtoDev\IDEntity\Types\IDEntityBody<extended>
+ * @covers \AvtoDev\IDEntity\Types\IDEntityBody
  */
 class IDEntityBodyTest extends AbstractIDEntityTestCase
 {

--- a/tests/Types/IDEntityCadastralNumberTest.php
+++ b/tests/Types/IDEntityCadastralNumberTest.php
@@ -10,7 +10,7 @@ use AvtoDev\IDEntity\Types\IDEntityCadastralNumber;
 use AvtoDev\StaticReferences\References\Entities\CadastralDistrict;
 
 /**
- * @covers \AvtoDev\IDEntity\Types\IDEntityCadastralNumber<extended>
+ * @covers \AvtoDev\IDEntity\Types\IDEntityCadastralNumber
  */
 class IDEntityCadastralNumberTest extends AbstractIDEntityTestCase
 {

--- a/tests/Types/IDEntityChassisTest.php
+++ b/tests/Types/IDEntityChassisTest.php
@@ -9,7 +9,7 @@ use AvtoDev\IDEntity\IDEntityInterface;
 use AvtoDev\IDEntity\Types\IDEntityChassis;
 
 /**
- * @covers \AvtoDev\IDEntity\Types\IDEntityChassis<extended>
+ * @covers \AvtoDev\IDEntity\Types\IDEntityChassis
  */
 class IDEntityChassisTest extends AbstractIDEntityTestCase
 {

--- a/tests/Types/IDEntityDriverLicenseNumberTest.php
+++ b/tests/Types/IDEntityDriverLicenseNumberTest.php
@@ -9,7 +9,7 @@ use AvtoDev\IDEntity\IDEntityInterface;
 use AvtoDev\IDEntity\Types\IDEntityDriverLicenseNumber;
 
 /**
- * @covers \AvtoDev\IDEntity\Types\IDEntityDriverLicenseNumber<extended>
+ * @covers \AvtoDev\IDEntity\Types\IDEntityDriverLicenseNumber
  */
 class IDEntityDriverLicenseNumberTest extends AbstractIDEntityTestCase
 {

--- a/tests/Types/IDEntityGrzTest.php
+++ b/tests/Types/IDEntityGrzTest.php
@@ -9,7 +9,7 @@ use AvtoDev\IDEntity\IDEntityInterface;
 use AvtoDev\IDEntity\Types\IDEntityGrz;
 
 /**
- * @covers \AvtoDev\IDEntity\Types\IDEntityGrz<extended>
+ * @covers \AvtoDev\IDEntity\Types\IDEntityGrz
  */
 class IDEntityGrzTest extends AbstractIDEntityTestCase
 {

--- a/tests/Types/IDEntityPtsTest.php
+++ b/tests/Types/IDEntityPtsTest.php
@@ -9,7 +9,7 @@ use AvtoDev\IDEntity\IDEntityInterface;
 use AvtoDev\IDEntity\Types\IDEntityPts;
 
 /**
- * @covers \AvtoDev\IDEntity\Types\IDEntityPts<extended>
+ * @covers \AvtoDev\IDEntity\Types\IDEntityPts
  */
 class IDEntityPtsTest extends AbstractIDEntityTestCase
 {

--- a/tests/Types/IDEntityStsTest.php
+++ b/tests/Types/IDEntityStsTest.php
@@ -9,7 +9,7 @@ use AvtoDev\IDEntity\IDEntityInterface;
 use AvtoDev\IDEntity\Types\IDEntitySts;
 
 /**
- * @covers \AvtoDev\IDEntity\Types\IDEntitySts<extended>
+ * @covers \AvtoDev\IDEntity\Types\IDEntitySts
  */
 class IDEntityStsTest extends AbstractIDEntityTestCase
 {

--- a/tests/Types/IDEntityUnknownTest.php
+++ b/tests/Types/IDEntityUnknownTest.php
@@ -9,7 +9,7 @@ use AvtoDev\IDEntity\IDEntityInterface;
 use AvtoDev\IDEntity\Types\IDEntityUnknown;
 
 /**
- * @covers \AvtoDev\IDEntity\Types\IDEntityUnknown<extended>
+ * @covers \AvtoDev\IDEntity\Types\IDEntityUnknown
  */
 class IDEntityUnknownTest extends AbstractIDEntityTestCase
 {

--- a/tests/Types/IDEntityVinTest.php
+++ b/tests/Types/IDEntityVinTest.php
@@ -9,7 +9,7 @@ use AvtoDev\IDEntity\IDEntityInterface;
 use AvtoDev\IDEntity\Types\IDEntityVin;
 
 /**
- * @covers \AvtoDev\IDEntity\Types\IDEntityVin<extended>
+ * @covers \AvtoDev\IDEntity\Types\IDEntityVin
  */
 class IDEntityVinTest extends AbstractIDEntityTestCase
 {


### PR DESCRIPTION
## Description

Laravel 10 and PHPUnit 10 support

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

## Changelog 

### Added

- Support Laravel `10.x`
- Support PHPUnit `v10`

### Changed

- Minimal require PHP version now is `8.0.2`
- Composer version up to `2.6.5`
- Package `phpstan/phpstan` up to `^1.10`
- Package `avto-dev/extended-laravel-validator` up to `^3.7`
- Package `avto-dev/static-references-laravel` up to `^4.5`
