### PR TITLE
Laravel 11 support was added

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,12 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['8.0', '8.1', '8.2']
+        php: ['8.1', '8.2', '8.3']
+        include:
+          - php: '8.1'
+            setup: [ basic, lowest ]
+            coverage: no
+            laravel: '^10.0'
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -37,7 +42,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         run: echo "output_dir=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies # Docs: <https://git.io/JfAKn#php---composer>
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.output_dir }}
           key: ${{ runner.os }}-composer-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
@@ -68,7 +73,7 @@ jobs: # Docs: <https://git.io/JvxXE>
           XDEBUG_MODE: coverage
         run: composer test-cover
 
-      - uses: codecov/codecov-action@v3 # Docs: <https://github.com/codecov/codecov-action>
+      - uses: codecov/codecov-action@v4 # Docs: <https://github.com/codecov/codecov-action>
         if: matrix.coverage == 'yes'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Laravel `11.x` support
+
+### Changed
+
+- Minimal Laravel version now is `10.0`
+- Version of `composer` in docker container updated up to `2.7.6`
+- Updated dev dependencies
+
 ## v5.7.0
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM php:8.0-alpine
+FROM php:8.3-alpine
 
 ENV COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.6.5 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.7.6 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
     && apk add --no-cache --virtual .build-deps linux-headers autoconf pkgconf make g++ gcc 1>/dev/null \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-3.2.0 1>/dev/null \
+    && pecl install xdebug-3.3.0 1>/dev/null \
     && apk del .build-deps \
     && mkdir --parents --mode=777 /src ${COMPOSER_HOME}/cache/repo ${COMPOSER_HOME}/cache/files \
     && ln -s /usr/bin/composer /usr/bin/c \

--- a/composer.json
+++ b/composer.json
@@ -14,21 +14,21 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "^8.1",
         "ext-mbstring": "*",
         "ext-json": "*",
         "avto-dev/extended-laravel-validator": "^3.7",
         "avto-dev/static-references-laravel": "^4.5",
-        "illuminate/support": "~9.0 || ~10.0",
-        "illuminate/config": "~9.0 || ~10.0",
-        "illuminate/contracts": "~9.0 || ~10.0",
-        "illuminate/container": "~9.0 || ~10.0",
+        "illuminate/support": "~10.0 || ~11.0",
+        "illuminate/config": "~10.0 || ~11.0",
+        "illuminate/contracts": "~10.0 || ~11.0",
+        "illuminate/container": "~10.0 || ~11.0",
         "danielstjules/stringy": "~3.1.0"
     },
     "require-dev": {
-        "laravel/laravel": "~9.0 || ~10.0",
-        "phpstan/phpstan": "~1.10",
-        "phpunit/phpunit": "^9.6 || ^10.4"
+        "laravel/laravel": "~10.0 || ~11.0",
+        "phpstan/phpstan": "^1.10.66",
+        "phpunit/phpunit": "^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,4 @@
 parameters:
   level: 'max'
-  checkGenericClassInNonGenericObjectType: false
   paths:
     - src

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,29 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
-         bootstrap="./tests/bootstrap.php"
-         colors="true"
-         forceCoversAnnotation="true">
-
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <coverage includeUncoveredFiles="false" processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-        <exclude>
-            <directory>./vendor</directory>
-            <directory>./tests</directory>
-        </exclude>
-        <report>
-            <clover outputFile="./coverage/clover.xml"/>
-            <html outputDirectory="./coverage/html"/>
-            <text outputFile="php://stdout" showUncoveredFiles="false"/>
-            <xml outputDirectory="./coverage/xml"/>
-        </report>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="./tests/bootstrap.php" colors="true" cacheDirectory=".phpunit.cache" requireCoverageMetadata="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage includeUncoveredFiles="false">
+    <report>
+      <clover outputFile="./coverage/clover.xml"/>
+      <html outputDirectory="./coverage/html"/>
+      <text outputFile="php://stdout" showUncoveredFiles="false"/>
+      <xml outputDirectory="./coverage/xml"/>
+    </report>
+  </coverage>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+      <directory>./tests</directory>
+    </exclude>
+  </source>
 </phpunit>

--- a/src/Types/TypedIDEntityInterface.php
+++ b/src/Types/TypedIDEntityInterface.php
@@ -5,6 +5,9 @@ namespace AvtoDev\IDEntity\Types;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 
+/**
+ * @extends Arrayable<string, mixed>
+ */
 interface TypedIDEntityInterface extends Arrayable, Jsonable
 {
     /**


### PR DESCRIPTION
## Description

Laravel 11 support

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

## Unreleased

### Added

- Laravel `11.x` support

### Changed

- Minimal Laravel version now is `10.0`
- Version of `composer` in docker container updated up to `2.7.6`
- Updated dev dependencies
