### PR TITLE
Update laravel to 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Laravel `12.x` support
+- Using `docker` with `compose` plugin instead of `docker-compose` for test environment
+
+### Changed
+
+- Package `avto-dev/extended-laravel-validator` up to `^5.0`
+
+## Fixed
+
+- Тests for `IDEntityBody`
+
 ## v5.9.0
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -14,25 +14,25 @@ help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[32m%-14s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 build: ## Build docker images, required for current package environment
-	docker-compose build
+	docker compose build
 
 latest: clean ## Install latest php dependencies
-	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --prefer-dist --prefer-stable
+	docker compose run $(RUN_APP_ARGS) app composer update -n --ansi --prefer-dist --prefer-stable
 
 install: clean ## Install regular php dependencies
-	docker-compose run $(RUN_APP_ARGS) app composer update -n --prefer-dist
+	docker compose run $(RUN_APP_ARGS) app composer update -n --prefer-dist
 
 lowest: clean ## Install lowest php dependencies
-	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --prefer-dist --prefer-lowest
+	docker compose run $(RUN_APP_ARGS) app composer update -n --ansi --prefer-dist --prefer-lowest
 
 test: ## Execute php tests and linters
-	docker-compose run $(RUN_APP_ARGS) app composer test
+	docker compose run $(RUN_APP_ARGS) app composer test
 
 test-cover: ## Execute php tests with coverage
-	docker-compose run --rm --user "0:0" -e 'XDEBUG_MODE=coverage' app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
+	docker compose run --rm --user "0:0" -e 'XDEBUG_MODE=coverage' app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
 
 shell: ## Start shell into container with php
-	docker-compose run $(RUN_APP_ARGS) app sh
+	docker compose run $(RUN_APP_ARGS) app sh
 
 clean: ## Remove all dependencies and unimportant files
 	-rm -Rf ./composer.lock ./vendor ./coverage ./tests/temp

--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,16 @@
         "php": "^8.1",
         "ext-mbstring": "*",
         "ext-json": "*",
-        "avto-dev/extended-laravel-validator": "^4.0",
+        "avto-dev/extended-laravel-validator": "^5.0",
         "avto-dev/static-references-laravel": "^4.5",
-        "illuminate/support": "~10.0 || ~11.0",
-        "illuminate/config": "~10.0 || ~11.0",
-        "illuminate/contracts": "~10.0 || ~11.0",
-        "illuminate/container": "~10.0 || ~11.0",
+        "illuminate/support": "~10.0 || ~11.0 || ~12.0",
+        "illuminate/config": "~10.0 || ~11.0 || ~12.0",
+        "illuminate/contracts": "~10.0 || ~11.0 || ~12.0",
+        "illuminate/container": "~10.0 || ~11.0 || ~12.0",
         "danielstjules/stringy": "~3.1.0"
     },
     "require-dev": {
-        "laravel/laravel": "~10.0 || ~11.0",
+        "laravel/laravel": "~10.0 || ~11.0 || ~12.0",
         "phpstan/phpstan": "^1.10.66",
         "phpunit/phpunit": "^10.5"
     },

--- a/tests/IDEntityTest.php
+++ b/tests/IDEntityTest.php
@@ -265,7 +265,7 @@ class IDEntityTest extends AbstractTestCase
     public function testMakeBodyAutoDetection(): void
     {
         $values = [
-            '0685251',
+            '06852512',
             'AT2113041080',
             'NZE141-9134919',
             'GD11231271',

--- a/tests/Types/IDEntityBodyTest.php
+++ b/tests/Types/IDEntityBodyTest.php
@@ -63,7 +63,7 @@ class IDEntityBodyTest extends AbstractIDEntityTestCase
             'GRX130 6026674',
             'JZX90 6562365',
 
-            '0685251',
+            '06852511',
             'AT2113041080',
             'NZE141-9134919',
             'GD11231271',
@@ -134,6 +134,7 @@ class IDEntityBodyTest extends AbstractIDEntityTestCase
     protected function getInvalidValues(): array
     {
         return [
+            '0685251',
             'TSMEYB21S00610448',
             '38:49:924785:832907',
             '',


### PR DESCRIPTION
## Unreleased

### Added

- Laravel `12.x` support
- Using `docker` with `compose` plugin instead of `docker-compose` for test environment

### Changed

- Package `avto-dev/extended-laravel-validator` up to `^5.0`

## Fixed

- Тests for `IDEntityBody`